### PR TITLE
fix(docx): export list and suffix-break of text

### DIFF
--- a/packages/docx/src/docx/exportDocx.ts
+++ b/packages/docx/src/docx/exportDocx.ts
@@ -119,6 +119,7 @@ function convertElementListToDocxChildren(
         element.valueList
           ?.map(item => item.value)
           .join('')
+          .replace(/^\n/, '')
           .split('\n')
           .map(
             (text, index) =>
@@ -179,7 +180,12 @@ function convertElementListToDocxChildren(
         appendParagraph()
         element.value = element.value.replace(/^\n/, '')
       }
+      const suffixBreak = /\n$/.test(element.value)
+      if (suffixBreak) {
+        element.value = element.value.replace(/\n$/, '')
+      }
       paragraphChild.push(convertElementToParagraphChild(element))
+      suffixBreak && appendParagraph()
     }
   }
   appendParagraph()


### PR DESCRIPTION
导出列表序号不对应和输入文本换行后按下Backspace后再Enter,\n出现在前面文字得末尾部分