### PR TITLE
fix(docx): export list and suffix-break of text

### DIFF
--- a/packages/docx/src/docx/exportDocx.ts
+++ b/packages/docx/src/docx/exportDocx.ts
@@ -119,6 +119,7 @@ function convertElementListToDocxChildren(
         element.valueList
           ?.map(item => item.value)
           .join('')
+          .replace(/^\n/, '')
           .split('\n')
           .map(
             (text, index) =>
@@ -175,11 +176,16 @@ function convertElementListToDocxChildren(
         ) || [])
       )
     } else {
+      let suffixBreak
       if (/^\n/.test(element.value)) {
         appendParagraph()
         element.value = element.value.replace(/^\n/, '')
+      } else if (/\n$/.test(element.value)) {
+        suffixBreak = true
+        element.value = element.value.replace(/\n$/, '')
       }
       paragraphChild.push(convertElementToParagraphChild(element))
+      suffixBreak && appendParagraph()
     }
   }
   appendParagraph()


### PR DESCRIPTION
输入几个文字比如'aa',复制几个文字到'aa'后面变成'abcd',此时光标定位到'ab'后面,按下enter,此时value成了'ab\n'导致生成文件下来未换行