### PR TITLE
Improve export docx support

### DIFF
--- a/packages/docx/src/docx/exportDocx.ts
+++ b/packages/docx/src/docx/exportDocx.ts
@@ -119,6 +119,7 @@ function convertElementListToDocxChildren(
         element.valueList
           ?.map(item => item.value)
           .join('')
+          .replace(/^\n/, '')
           .split('\n')
           .map(
             (text, index) =>
@@ -175,11 +176,16 @@ function convertElementListToDocxChildren(
         ) || [])
       )
     } else {
+      let suffixBreak
       if (/^\n/.test(element.value)) {
         appendParagraph()
         element.value = element.value.replace(/^\n/, '')
+      } else if (/\n$/.test(element.value)) {
+        suffixBreak = true
+        element.value = element.value.replace(/\n$/, '')
       }
       paragraphChild.push(convertElementToParagraphChild(element))
+      suffixBreak && appendParagraph()
     }
   }
   appendParagraph()


### PR DESCRIPTION
1. 修正canvas-editor编辑文件部分文本换行后value为xxx\n导致下载文件没有换行,举例: 输入"ab",复制"bc"到光标后面,此时光标定位到"ab"后面按下enter,此时值为"ab\n";
2. 支持内容设置的水平对齐方式,验证了普通文本、标题、表格内容、列表等导出可以正常展示；
3. 支持用户自定义设置文本像素转化为pt，避免使用word打开的文字大小不匹配。