### PR TITLE
增加自定义工具栏功能和文档说明

### DIFF
--- a/packages/floatingToolbar/README.md
+++ b/packages/floatingToolbar/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">floating toolbar plugin for canvas-editor</p>
 
-## usage
+## 基本用法
 
 ```bash
 npm i @hufe921/canvas-editor-plugin-floating-toolbar --save
@@ -14,4 +14,114 @@ import floatingToolbarPlugin from '@hufe921/canvas-editor-plugin-floating-toolba
 
 const instance = new Editor()
 instance.use(floatingToolbarPlugin)
+```
+
+## 高级用法
+
+### 自定义工具栏
+
+```javascript
+import Editor from '@hufe921/canvas-editor'
+import floatingToolbarPlugin from '@hufe921/canvas-editor-plugin-floating-toolbar'
+
+const instance = new Editor()
+
+// 配置选项
+const options = {
+  // 是否显示默认工具栏项，默认为true
+  showDefaultItems: true,
+
+  // 自定义工具栏项
+  customItems: [
+    {
+      key: 'custom-ai-polish',
+      title: 'AI润色',
+      icon: '.icon-ai-polish', // CSS类图标（以.开头表示使用CSS类）
+      callback: editor => {
+        alert('AI润色功能尚未实现')
+      }
+    },
+    // 添加分隔符
+    {
+      isDivider: true,
+      key: 'divider-1' // key对分隔符是可选的
+    },
+    {
+      key: 'custom-text-icon',
+      title: '文本图标',
+      icon: 'T', // 文本图标（直接使用字符作为图标）
+      callback: editor => {
+        // 自定义功能
+      }
+    }
+  ]
+}
+
+instance.use(floatingToolbarPlugin, options)
+```
+
+### 图标类型
+
+浮动工具栏支持两种类型的图标:
+
+1. **CSS 类图标**
+
+   - 使用`.className`格式，如：`.icon-align-left`
+   - 插件会自动将其解析为 CSS 类名并应用到图标元素上
+   - 您需要在 CSS 中定义相应的样式，例如：
+
+   ```css
+   /* 方法1: 使用SVG文件 */
+   .icon-ai-polish {
+     background-image: url('/path/to/icons/ai-polish.svg');
+     background-position: center;
+     background-repeat: no-repeat;
+     background-size: contain;
+   }
+   ```
+
+2. **文本图标**
+   - 直接使用文本字符作为图标，如：`T`、`B`、`I`等
+   - 适合简单的图标表示，会居中显示在工具栏按钮中
+
+### 分隔符
+
+您可以在工具栏中添加分隔符来分隔不同功能的按钮：
+
+```javascript
+{
+  isDivider: true,
+  key: 'divider-name'  // 可选，用于标识分隔符
+}
+```
+
+分隔符会在工具栏中显示为垂直线。
+
+## 接口说明
+
+### 选项接口
+
+```typescript
+// 工具栏配置选项
+interface IFloatingToolbarOptions {
+  customItems?: IToolbarItem[] // 自定义工具栏项
+  showDefaultItems?: boolean // 是否显示默认工具栏项
+}
+
+// 分隔符项
+interface IToolbarDivider {
+  isDivider: true
+  key?: string // 可选的标识符
+}
+
+// 常规工具栏项
+interface IToolbarAction {
+  key: string // 唯一标识
+  title?: string // 悬停提示
+  icon?: string // 图标（CSS类名或自定义文本）
+  callback: (editor: Editor) => void // 点击回调
+}
+
+// 工具栏项可以是常规项或分隔符
+type IToolbarItem = IToolbarDivider | IToolbarAction
 ```

--- a/packages/floatingToolbar/src/floatingToolbar/icons/ai-polish.svg
+++ b/packages/floatingToolbar/src/floatingToolbar/icons/ai-polish.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="3" width="20" height="18" rx="2" ry="2"></rect>
+  <!-- A字母 -->
+  <path d="M8 17L11 7"></path>
+  <path d="M14 17L11 7"></path>
+  <path d="M7 13h8"></path>
+  <!-- I字母 -->
+  <path d="M17 7v10"></path>
+</svg>

--- a/packages/floatingToolbar/src/floatingToolbar/interface/index.ts
+++ b/packages/floatingToolbar/src/floatingToolbar/interface/index.ts
@@ -1,8 +1,30 @@
 import Editor from '@hufe921/canvas-editor'
 
+export interface IToolbarDivider {
+  isDivider: true
+  key?: string
+}
+
+export interface IToolbarAction {
+  key: string
+  title?: string
+  icon?: string // CSS类名或自定义图标字符串
+  isDivider?: false
+  callback: (editor: Editor) => void
+}
+
+export type IToolbarItem = IToolbarDivider | IToolbarAction
+
 export interface IToolbarRegister {
   key?: string
   isDivider?: boolean
+  title?: string
+  icon?: string
   render?: (container: HTMLDivElement, editor: Editor) => void
   callback?: (editor: Editor) => void
+}
+
+export interface IFloatingToolbarOptions {
+  customItems?: IToolbarItem[]
+  showDefaultItems?: boolean
 }

--- a/packages/floatingToolbar/src/floatingToolbar/style/index.scss
+++ b/packages/floatingToolbar/src/floatingToolbar/style/index.scss
@@ -97,4 +97,38 @@
       background: url(../icons/highlight.svg);
     }
   }
+
+  // 通用项样式
+  .ce-item {
+    min-width: 20px;
+    margin: 0 3px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+
+    &:hover,
+    &.active {
+      background-color: rgba(25, 55, 88, .07);
+    }
+
+    i {
+      width: 16px;
+      height: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-style: normal;
+      font-size: 14px;
+    }
+  }
+}
+
+/* AI润色图标 */
+.icon-ai-polish {
+  background-image: url(../icons/ai-polish.svg);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
 }

--- a/packages/floatingToolbar/src/main.ts
+++ b/packages/floatingToolbar/src/main.ts
@@ -1,10 +1,48 @@
 import Editor from '@hufe921/canvas-editor'
 import floatingToolbarPlugin from './floatingToolbar'
+import { IFloatingToolbarOptions } from './floatingToolbar/interface'
 
 window.onload = function () {
   const container = document.querySelector<HTMLDivElement>('#editor')!
   const instance = new Editor(container, {
     main: []
   })
-  instance.use(floatingToolbarPlugin)
+
+  // 定义自定义工具栏配置
+  const toolbarOptions: IFloatingToolbarOptions = {
+    // 是否显示默认工具栏项，默认为true
+    showDefaultItems: true,
+
+    // 自定义工具栏项
+    customItems: [
+      // 添加一个分隔符
+      {
+        isDivider: true,
+        key: 'divider-1' // key对分隔符可选
+      },
+      {
+        key: 'custom-ai-polish',
+        title: 'AI润色',
+        // 使用CSS类作为图标（以.开头表示类名）
+        icon: '.icon-ai-polish',
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        callback: _editor => {
+          alert('AI润色功能尚未实现')
+        }
+      },
+      {
+        key: 'custom-text-icon',
+        title: '文本图标示例',
+        // 使用文本作为图标（不以.或#开头即为文本）
+        icon: 'T',
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        callback: _editor => {
+          alert('使用文本作为图标示例')
+        }
+      }
+    ]
+  }
+
+  // 使用带有自定义选项的浮动工具栏插件)
+  instance.use(floatingToolbarPlugin, toolbarOptions)
 }


### PR DESCRIPTION
通过目前已有的接口进行了扩展，允许用户添加分栏符和自定义的图标

<img width="581" alt="image" src="https://github.com/user-attachments/assets/a5d6f3dc-6475-451d-a58b-72fb451575a2" />
